### PR TITLE
DFU Library upgrades

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,6 +38,6 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'no.nordicsemi.android:dfu:1.8.0'
+    implementation 'no.nordicsemi.android:dfu:1.11.1'
 }
   

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nordic-dfu",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Nordic Device Firmware Update for React Native",
   "main": "index.js",
   "url": "https://github.com/Pilloxa/react-native-nordic-dfu",

--- a/react-native-nordic-dfu.podspec
+++ b/react-native-nordic-dfu.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React'
-  s.dependency 'iOSDFULibrary', '~> 4.9.0'
+  s.dependency 'iOSDFULibrary', '~> 4.10.3'
 end


### PR DESCRIPTION
Update our React Native library version to 3.3.1, our iOS DFU library version to 4.10.3, and our Android DFU library version to 1.11.11.